### PR TITLE
change card-footer from display:none to opacity:0

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -57,7 +57,7 @@
     }
 
     .card-footer {
-      display: none;
+      opacity: 0;
     }
   }
 }


### PR DESCRIPTION
Display none: doesn't display link to field.
Opacity 0: doesn't show footer but link will still be clickable. 

<img width="566" alt="Screen Shot 2022-11-16 at 14 58 30" src="https://user-images.githubusercontent.com/109743083/202097634-2eea60bb-bedb-47cd-8d53-aba5ddbe046d.png">
