### PR TITLE
Image bug and removed the usages of "featured_img"

### DIFF
--- a/app/controllers/fields_controller.rb
+++ b/app/controllers/fields_controller.rb
@@ -61,7 +61,6 @@ class FieldsController < ApplicationController
   def set_new_field
     @field = Field.new(fields_params)
     @field.user = current_user
-    @field.featured_img = @field.images.first.key
     authorize @field
   end
 

--- a/app/views/fields/_card.html.erb
+++ b/app/views/fields/_card.html.erb
@@ -1,4 +1,4 @@
-<div class="card card-field text-white card-has-bg click-col" style="background-image:url(<%= field.featured_img ? cl_image_path(field.featured_img) : image_url('https://images.unsplash.com/photo-1573351106568-7c0784fb6456?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=640&q=80') %>);">
+<div class="card card-field text-white card-has-bg click-col" style="background-image:url(<%= field.images.first.key ? cl_image_path(field.images.first.key) : image_url('https://images.unsplash.com/photo-1573351106568-7c0784fb6456?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=640&q=80') %>);">
   <div class="card-img-overlay d-flex flex-column">
     <div class="card-body-field">
       <h3 class="card-title mt-0 text-white"><%= field.name %></h3>

--- a/app/views/fields/_map_popup.html.erb
+++ b/app/views/fields/_map_popup.html.erb
@@ -1,5 +1,5 @@
 <div class="popup-field-img"
-      style="background-image:url(<%= field.images.attached? ? cl_image_path(field.featured_img) : image_url('https://images.unsplash.com/photo-1573351106568-7c0784fb6456?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=640&q=80') %>);">
+      style="background-image:url(<%= field.images.first.key ? cl_image_path(field.images.first.key) : image_url('https://images.unsplash.com/photo-1573351106568-7c0784fb6456?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=640&q=80') %>);">
   <div class="popup-text">
     <h2 class="text-white"><%= field.name %></h2>
     <p class="badge bg-primary mb-1"><%= field.location %></p>


### PR DESCRIPTION
There was a bug related to the featured image.

Before the featured image was a saved URL in the database.
Now the featured image is the .first image from the attached images in AS.

If this seems to work well, let's remove "featured_img" from the database.